### PR TITLE
Update Rust to 1.88 (fixes #19)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.75-slim-bookworm AS builder
+FROM rust:1.88-slim-bookworm AS builder
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
#19 does not work on Coolify because Cargo does not understand the Cargo.lock format. This PR fixes that.