### PR TITLE
Change to endsWith to accomodate full path

### DIFF
--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -22,7 +22,7 @@ const openRouterHeaders = {
 proxy.use("*", blockAICodingAgents);
 
 proxy.use((c, next) => {
-  if (c.req.path === "/v1/models") {
+  if (c.req.path.endsWith("/v1/models")) {
     return next();
   }
   return requireApiKey(c, next);


### PR DESCRIPTION
 Since `c.req.path` returns a full path, and not a relative path (see deprecated routePath: https://hono.dev/docs/helpers/route), this change makes sure the path actually matches - this commit has been tested.