### PR TITLE
fix: improve model selection logic in completion request handler

### DIFF
--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -187,7 +187,12 @@ async function handleCompletionRequest(
 
     const allowedSet = new Set(allowedLanguageModels);
     if (!allowedSet.has(requestBody.model)) {
-      requestBody.model = allowedLanguageModels[0];
+      const matchedModel = allowedLanguageModels.find((m) => m.split("/")[1] === requestBody.model);
+      if (matchedModel) {
+        requestBody.model = matchedModel;
+      } else {
+        requestBody.model = allowedLanguageModels[0];
+      }
     }
 
     requestBody.user = `user_${user.id}`;


### PR DESCRIPTION
Hi!

I updated the logic for handling model selection in the `handleCompletionRequest` function. Now, if the requested model name isn't a direct match, the code tries to find the model by matching on the model name after the `/` character before defaulting to the first allowed model.

fixes #72 