### PR TITLE
fix model name matching

### DIFF
--- a/src/routes/proxy/shared.ts
+++ b/src/routes/proxy/shared.ts
@@ -99,8 +99,16 @@ export const apiHeaders = () => ({
   ...openRouterHeaders,
 });
 
-export const resolveModel = (model: string, pool: string[]) =>
-  pool.includes(model) ? model : pool[0];
+export const resolveModel = (model: string, pool: string[]) => {
+  if (pool.includes(model)) {
+    return model;
+  }
+  const matchedModel = pool.find((m) => m.split("/")[1] === model);
+  if (matchedModel) {
+    return matchedModel;
+  }
+  return pool[0];
+};
 
 export const logRequest = (
   c: Ctx,


### PR DESCRIPTION
Almost the same fix applied as #73 

> In completion (and responses?) requests, when the model name is set to something like gemini-2.5-flash-preview instead of google/gemini-2.5-flash-preview, it still works, but the model name is logged and displayed as qwen/qwen3-32b.

P.S. - This issue (#72) used to only affect the logs now it also uses the wrong model.