### PR TITLE
Preserve OpenRouter status codes in streaming responses

### DIFF
--- a/src/routes/proxy/v1/general.ts
+++ b/src/routes/proxy/v1/general.ts
@@ -78,6 +78,7 @@ async function handleProxy(c: Ctx, endpoint: string) {
 
     return stream(c, async (s) => {
       c.header("Content-Type", "text/event-stream");
+      c.status(res.status as ContentfulStatusCode);
       const reader = res.body?.getReader(),
         decoder = new TextDecoder(),
         chunks: string[] = [];


### PR DESCRIPTION
Previously, streaming responses always returned HTTP 200 regardless of the upstream status code. Now preserves the original status from OpenRouter.