### PR TITLE
dev: skip Slack verification in development mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: hc-ai-db
     environment:
       POSTGRES_USER: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: hc-ai-db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: hc-ai
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -106,7 +106,51 @@ auth.use(
   }),
 );
 
-auth.get("/login", (c) => {
+auth.get("/login", async (c) => {
+  if (env.NODE_ENV === "development") {
+    const testSlackId = `dev_${crypto.randomUUID().slice(0, 8)}`;
+    const testEmail = `dev_${crypto.randomUUID().slice(0, 8)}@test.com`;
+    const testName = "Dev User";
+
+    let [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.slackId, testSlackId))
+      .limit(1);
+
+    if (!user) {
+      [user] = await db
+        .insert(users)
+        .values({
+          slackId: testSlackId,
+          email: testEmail,
+          name: testName,
+          isIdvVerified: false,
+        })
+        .returning();
+    }
+
+    const sessionToken = crypto.randomUUID();
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + 30);
+
+    await db.insert(sessions).values({
+      userId: user.id,
+      token: sessionToken,
+      expiresAt,
+    });
+
+    setCookie(c, "session_token", sessionToken, {
+      httpOnly: true,
+      secure: false,
+      sameSite: "Lax",
+      maxAge: 60 * 60 * 24 * 30,
+      path: "/",
+    });
+
+    return c.redirect("/dashboard");
+  }
+
   const clientId = env.HACK_CLUB_CLIENT_ID;
   const redirectUri = `${env.BASE_URL}/auth/callback`;
   const state = crypto.randomUUID();

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -125,7 +125,7 @@ auth.get("/login", async (c) => {
           slackId: testSlackId,
           email: testEmail,
           name: testName,
-          isIdvVerified: false,
+          isIdvVerified: true,
         })
         .returning();
     }


### PR DESCRIPTION
This pull request introduces a Docker Compose setup for local development and adds a development-only shortcut for authentication that creates a test user and session when running in a development environment. These changes streamline the development workflow by simplifying database setup and enabling quick login for developers.

**Development environment improvements:**

* Added a `docker-compose.yml` file to set up a local PostgreSQL instance with persistent storage and health checks, making it easier to run the app locally without manual database setup.

**Authentication enhancements for development:**

* Updated the `/login` route in `src/routes/auth.ts` to automatically create and log in a test user with a session when `NODE_ENV` is set to `development`, bypassing the normal authentication flow for faster local testing.