### PR TITLE
Add upstream header timeout

### DIFF
--- a/src/routes/proxy/v1/general.ts
+++ b/src/routes/proxy/v1/general.ts
@@ -24,8 +24,33 @@ import {
 // this on log; the point is just to make a single oversized burst impossible
 // when the user is already near their daily cap.
 const IMAGE_GENERATION_RESERVATION = 0.25;
+const UPSTREAM_HEADER_TIMEOUT_MS = 5_000;
 
 const general = new Hono<{ Variables: AppVariables }>();
+
+async function fetchWithHeaderTimeout(
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    UPSTREAM_HEADER_TIMEOUT_MS,
+  );
+
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new HTTPException(504, {
+        message: `Upstream did not return response headers within ${UPSTREAM_HEADER_TIMEOUT_MS}ms`,
+      });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
 async function handleProxy(c: Ctx, endpoint: string) {
   const start = Date.now();
@@ -39,11 +64,14 @@ async function handleProxy(c: Ctx, endpoint: string) {
 
     await reserveCharge(c, await estimateUpstreamCost(body));
 
-    const res = await fetch(`${env.OPENAI_API_URL}/v1/${endpoint}`, {
-      method: "POST",
-      headers: apiHeaders(c),
-      body: JSON.stringify(body),
-    });
+    const res = await fetchWithHeaderTimeout(
+      `${env.OPENAI_API_URL}/v1/${endpoint}`,
+      {
+        method: "POST",
+        headers: apiHeaders(c),
+        body: JSON.stringify(body),
+      },
+    );
 
     if (!body.stream && endpoint !== "embeddings") {
       // For non-streaming requests, we still need to keep Cloudflare alive
@@ -131,6 +159,8 @@ async function handleProxy(c: Ctx, endpoint: string) {
       { prompt: 0, completion: 0, total: 0, cost: 0 },
       duration,
     );
+
+    if (error instanceof HTTPException) throw error;
 
     throw new HTTPException(500, { message: "Internal server error" });
   }


### PR DESCRIPTION
## Summary
- add a 5s timeout while waiting for upstream OpenRouter response headers on chat/responses/embeddings proxy requests
- return a 504 when upstream never returns headers instead of leaving clients waiting indefinitely
- clear the timeout after headers arrive so long streaming responses are not aborted by this guard
- side effect: preserves intentional `HTTPException`s in this proxy path, fixing a recently introduced bug where hitting the spending limit returned a generic 500 instead of the limit error

## Test
- bun run typecheck
- format failures are preexisting

## Why
Occasionally HackAI seems to get stuck responding. I'm not sure why, and it sucks every time, because I would rather use another provider like Copilot instead of waiting 5 minutes for the default timeout length. By aborting after 5 seconds this rules out the possibility that it's waiting on OpenRouter to respond.

## Disclosure
Generated by GPT-5.5 with human oversight