### PR TITLE
Improve activity request table

### DIFF
--- a/src/routes/activity.tsx
+++ b/src/routes/activity.tsx
@@ -1,35 +1,93 @@
 import * as Sentry from "@sentry/bun";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq, lt, or } from "drizzle-orm";
 import { Hono } from "hono";
 import { db } from "../db";
-import { requestLogs } from "../db/schema";
+import { apiKeys, requestLogs } from "../db/schema";
+import { fetchAllModels } from "../lib/models";
 import { getDailySpending, getUserStats } from "../lib/stats";
 import { requireAuth } from "../middleware/auth";
 import type { AppVariables } from "../types";
-import { Activity } from "../views/activity";
+import {
+  Activity,
+  LoadMoreRequestsButton,
+  RecentRequestsRows,
+} from "../views/activity";
 
 const activity = new Hono<{ Variables: AppVariables }>();
+const PAGE_SIZE = 50;
+
+const getModelNameById = async () => {
+  try {
+    const { languageModels, imageModels, embeddingModels } =
+      await Sentry.startSpan({ name: "fetch.models" }, () => fetchAllModels());
+    return new Map(
+      [...languageModels, ...imageModels, ...embeddingModels].map((model) => [
+        model.id,
+        model.name || model.id,
+      ]),
+    );
+  } catch {
+    return new Map<string, string>();
+  }
+};
+
+const getRecentLogs = async (
+  userId: string,
+  before?: { timestamp: Date; id: string },
+) => {
+  const rows = await Sentry.startSpan({ name: "db.select.recentLogs" }, () =>
+    db
+      .select({
+        id: requestLogs.id,
+        model: requestLogs.model,
+        promptTokens: requestLogs.promptTokens,
+        completionTokens: requestLogs.completionTokens,
+        totalTokens: requestLogs.totalTokens,
+        timestamp: requestLogs.timestamp,
+        duration: requestLogs.duration,
+        ip: requestLogs.ip,
+        response: requestLogs.response,
+        apiKeyName: apiKeys.name,
+      })
+      .from(requestLogs)
+      .innerJoin(apiKeys, eq(requestLogs.apiKeyId, apiKeys.id))
+      .where(
+        before
+          ? and(
+              eq(requestLogs.userId, userId),
+              or(
+                lt(requestLogs.timestamp, before.timestamp),
+                and(
+                  eq(requestLogs.timestamp, before.timestamp),
+                  lt(requestLogs.id, before.id),
+                ),
+              ),
+            )
+          : eq(requestLogs.userId, userId),
+      )
+      .orderBy(desc(requestLogs.timestamp), desc(requestLogs.id))
+      .limit(PAGE_SIZE + 1),
+  );
+
+  const hasMore = rows.length > PAGE_SIZE;
+  const page = rows.slice(0, PAGE_SIZE);
+  const modelNameById = await getModelNameById();
+
+  return {
+    hasMore,
+    logs: page.map((row) => ({
+      ...row,
+      modelName: modelNameById.get(row.model) || row.model,
+    })),
+  };
+};
 
 activity.get("/activity", requireAuth, async (c) => {
   const user = c.get("user");
 
-  const [stats, recentLogs, dailySpending] = await Promise.all([
+  const [stats, recent, dailySpending] = await Promise.all([
     getUserStats(user.id),
-    Sentry.startSpan({ name: "db.select.recentLogs" }, () =>
-      db
-        .select({
-          id: requestLogs.id,
-          model: requestLogs.model,
-          totalTokens: requestLogs.totalTokens,
-          timestamp: requestLogs.timestamp,
-          duration: requestLogs.duration,
-          ip: requestLogs.ip,
-        })
-        .from(requestLogs)
-        .where(eq(requestLogs.userId, user.id))
-        .orderBy(desc(requestLogs.timestamp))
-        .limit(50),
-    ),
+    getRecentLogs(user.id),
     getDailySpending(user.id),
   ]);
 
@@ -37,9 +95,39 @@ activity.get("/activity", requireAuth, async (c) => {
     <Activity
       user={user}
       stats={stats}
-      recentLogs={recentLogs}
+      recentLogs={recent.logs}
+      hasMoreRecentLogs={recent.hasMore}
       dailySpending={dailySpending}
     />,
+  );
+});
+
+activity.get("/activity/requests", requireAuth, async (c) => {
+  const user = c.get("user");
+  const beforeTimestamp = c.req.query("before");
+  const beforeId = c.req.query("beforeId");
+  const beforeDate = beforeTimestamp ? new Date(beforeTimestamp) : null;
+
+  if (!beforeDate || Number.isNaN(beforeDate.getTime()) || !beforeId) {
+    return c.body(null, 400);
+  }
+
+  const recent = await getRecentLogs(user.id, {
+    timestamp: beforeDate,
+    id: beforeId,
+  });
+
+  return c.html(
+    <>
+      <RecentRequestsRows recentLogs={recent.logs} />
+      <div
+        id="load-more-requests"
+        class="mt-4 flex justify-center"
+        hx-swap-oob="outerHTML"
+      >
+        {recent.hasMore && <LoadMoreRequestsButton recentLogs={recent.logs} />}
+      </div>
+    </>,
   );
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,19 @@ type ApiKey = typeof apiKeys.$inferSelect;
 type RequestLog = typeof requestLogs.$inferSelect;
 export type DashboardRequestLog = Pick<
   RequestLog,
-  "id" | "model" | "totalTokens" | "timestamp" | "duration" | "ip"
->;
+  | "id"
+  | "model"
+  | "promptTokens"
+  | "completionTokens"
+  | "totalTokens"
+  | "timestamp"
+  | "duration"
+  | "ip"
+  | "response"
+> & {
+  apiKeyName: string;
+  modelName: string;
+};
 export type DashboardApiKey = Pick<ApiKey, "id" | "name" | "createdAt"> & {
   keyPreview: string;
 };

--- a/src/views/activity.tsx
+++ b/src/views/activity.tsx
@@ -171,12 +171,12 @@ export const RecentRequestsRows = ({
         return (
           <tr class="border-b border-brand-border/50 hover:bg-brand-bg/30 transition-colors">
             <td class="py-2 px-4 text-sm text-brand-text font-medium whitespace-nowrap">
-              <abbr class="no-underline" title={formatFullTime(row.timestamp)}>
+              <abbr title={formatFullTime(row.timestamp)}>
                 {formatRelativeTime(row.timestamp)}
               </abbr>{" "}
               <span class="text-brand-text/40">•</span>{" "}
               <abbr
-                class="no-underline cursor-help"
+                class="cursor-help"
                 title={info}
                 style={`color: ${infoColor}`}
               >
@@ -203,7 +203,7 @@ export const RecentRequestsRows = ({
             </td>
             <td class="py-2 px-4 text-sm font-medium whitespace-nowrap">
               <abbr
-                class={`no-underline ${errorMessage ? "text-red-500" : "text-green-400"}`}
+                class={errorMessage ? "text-red-500" : "text-green-400"}
                 title={errorMessage || "Request completed"}
               >
                 {errorMessage ? "Error" : "OK"}

--- a/src/views/activity.tsx
+++ b/src/views/activity.tsx
@@ -186,7 +186,7 @@ export const RecentRequestsRows = ({
             <td class="py-2 px-4 text-sm font-medium max-w-64 truncate">
               <a
                 href={`/models/${row.model}`}
-                class="text-brand-primary hover:text-brand-primary-hover transition-colors"
+                class="text-brand-text underline hover:text-brand-primary-hover transition-colors"
               >
                 {displayModelName(row.modelName)}
               </a>

--- a/src/views/activity.tsx
+++ b/src/views/activity.tsx
@@ -2,13 +2,13 @@ import type { DashboardRequestLog, Stats, User } from "../types";
 import { EmptyState } from "./components/EmptyState";
 import { Header } from "./components/Header";
 import { StatCard } from "./components/StatCard";
-import { Table } from "./components/Table";
 import { Layout } from "./layout";
 
 type ActivityProps = {
   user: User;
   stats: Stats;
   recentLogs: DashboardRequestLog[];
+  hasMoreRecentLogs: boolean;
   dailySpending?: number;
 };
 
@@ -16,10 +16,11 @@ export const Activity = ({
   user,
   stats,
   recentLogs,
+  hasMoreRecentLogs,
   dailySpending,
 }: ActivityProps) => {
   return (
-    <Layout title="Activity" user={user}>
+    <Layout title="Activity" includeHtmx user={user}>
       <Header title="hackai" user={user} dailySpending={dailySpending} />
 
       <div class="w-full max-w-6xl mx-auto px-4 py-8">
@@ -48,43 +49,195 @@ export const Activity = ({
         <h2 class="text-2xl font-bold mb-6 text-brand-heading">
           Recent Requests
         </h2>
-        <RecentRequestsTable recentLogs={recentLogs} />
+        <RecentRequestsTable
+          recentLogs={recentLogs}
+          hasMore={hasMoreRecentLogs}
+        />
       </div>
     </Layout>
   );
 };
 
+const formatRelativeTime = (timestamp: Date) => {
+  const diff = Math.floor((Date.now() - new Date(timestamp).getTime()) / 1000);
+  if (diff < 60) return "just now";
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  if (diff < 604800) return `${Math.floor(diff / 86400)}d ago`;
+  return new Date(timestamp).toLocaleDateString();
+};
+
+const formatFullTime = (timestamp: Date) =>
+  new Date(timestamp).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "medium",
+  });
+
+const formatDuration = (ms: number) => {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)}s`;
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.floor((ms % 60_000) / 1000);
+  return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+};
+
+const hashColor = (value: string) => {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 31 + value.charCodeAt(i)) | 0;
+  }
+  return `oklch(78% 0.16 ${Math.abs(hash) % 360})`;
+};
+
+const displayModelName = (name: string) => {
+  const afterColon = name.split(":").at(-1)?.trim();
+  return afterColon || name;
+};
+
+const getErrorMessage = (response: unknown): string | null => {
+  if (!response || typeof response !== "object") return null;
+  const data = response as Record<string, unknown>;
+  const error = data.error;
+
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    const errorData = error as Record<string, unknown>;
+    if (typeof errorData.message === "string") return errorData.message;
+    if (typeof errorData.code === "string") return errorData.code;
+  }
+
+  if (typeof data.message === "string" && !Array.isArray(data.choices)) {
+    return data.message;
+  }
+
+  return null;
+};
+
 const RecentRequestsTable = ({
   recentLogs,
+  hasMore,
 }: {
   recentLogs: DashboardRequestLog[];
+  hasMore: boolean;
 }) => {
   if (recentLogs.length === 0) {
     return <EmptyState message="No requests yet." />;
   }
 
   return (
-    <Table
-      columns={[
-        {
-          header: "Time",
-          render: (row) => {
-            const diff = Math.floor(
-              (Date.now() - new Date(row.timestamp).getTime()) / 1000,
-            );
-            if (diff < 60) return "just now";
-            if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-            if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-            if (diff < 604800) return `${Math.floor(diff / 86400)}d ago`;
-            return new Date(row.timestamp).toLocaleDateString();
-          },
-        },
-        { header: "Model", key: "model" },
-        { header: "Tokens", render: (row) => row.totalTokens.toLocaleString() },
-        { header: "Duration", render: (row) => `${row.duration}ms` },
-        { header: "IP", key: "ip" },
-      ]}
-      data={recentLogs}
-    />
+    <>
+      <div class="overflow-x-auto border-2 border-brand-border bg-brand-surface rounded-2xl shadow-sm transition-colors">
+        <table class="w-full border-collapse">
+          <thead>
+            <tr class="border-b-2 border-brand-border bg-brand-bg/50">
+              <th class="text-left py-4 px-4 font-bold text-sm text-brand-heading uppercase tracking-wider">
+                Time
+              </th>
+              <th class="text-left py-4 px-4 font-bold text-sm text-brand-heading uppercase tracking-wider">
+                Model
+              </th>
+              <th class="text-left py-4 px-4 font-bold text-sm text-brand-heading uppercase tracking-wider">
+                Tokens
+              </th>
+              <th class="text-left py-4 px-4 font-bold text-sm text-brand-heading uppercase tracking-wider">
+                Result
+              </th>
+            </tr>
+          </thead>
+          <tbody id="recent-request-rows">
+            <RecentRequestsRows recentLogs={recentLogs} />
+          </tbody>
+        </table>
+      </div>
+      <div id="load-more-requests" class="mt-4 flex justify-center">
+        {hasMore && <LoadMoreRequestsButton recentLogs={recentLogs} />}
+      </div>
+    </>
+  );
+};
+
+export const RecentRequestsRows = ({
+  recentLogs,
+}: {
+  recentLogs: DashboardRequestLog[];
+}) => {
+  return (
+    <>
+      {recentLogs.map((row) => {
+        const errorMessage = getErrorMessage(row.response);
+        const info = `Key: ${row.apiKeyName}\nIP: ${row.ip}`;
+        const infoColor = hashColor(`${row.apiKeyName}:${row.ip}`);
+
+        return (
+          <tr class="border-b border-brand-border/50 hover:bg-brand-bg/30 transition-colors">
+            <td class="py-2 px-4 text-sm text-brand-text font-medium whitespace-nowrap">
+              <abbr class="no-underline" title={formatFullTime(row.timestamp)}>
+                {formatRelativeTime(row.timestamp)}
+              </abbr>{" "}
+              <span class="text-brand-text/40">•</span>{" "}
+              <abbr
+                class="no-underline cursor-help"
+                title={info}
+                style={`color: ${infoColor}`}
+              >
+                i
+              </abbr>
+            </td>
+            <td class="py-2 px-4 text-sm font-medium max-w-64 truncate">
+              <a
+                href={`/models/${row.model}`}
+                class="text-brand-primary hover:text-brand-primary-hover transition-colors"
+              >
+                {displayModelName(row.modelName)}
+              </a>
+            </td>
+            <td class="py-2 px-4 text-sm text-brand-text font-medium whitespace-nowrap">
+              {errorMessage ? (
+                <span class="text-brand-text/60">No usage</span>
+              ) : (
+                <span>
+                  {row.promptTokens.toLocaleString()} in /{" "}
+                  {row.completionTokens.toLocaleString()} out
+                </span>
+              )}
+            </td>
+            <td class="py-2 px-4 text-sm font-medium whitespace-nowrap">
+              <abbr
+                class={`no-underline ${errorMessage ? "text-red-500" : "text-green-400"}`}
+                title={errorMessage || "Request completed"}
+              >
+                {errorMessage ? "Error" : "OK"}
+              </abbr>
+              <span class="text-brand-text/40"> · </span>
+              <span class="text-brand-text">
+                {formatDuration(row.duration)}
+              </span>
+            </td>
+          </tr>
+        );
+      })}
+    </>
+  );
+};
+
+export const LoadMoreRequestsButton = ({
+  recentLogs,
+}: {
+  recentLogs: DashboardRequestLog[];
+}) => {
+  const last = recentLogs.at(-1);
+  if (!last) return null;
+
+  return (
+    <button
+      type="button"
+      class="px-4 py-2 rounded-full bg-brand-primary text-white text-sm font-medium hover:bg-brand-primary-hover transition-colors disabled:opacity-60"
+      hx-get={`/activity/requests?before=${encodeURIComponent(last.timestamp.toISOString())}&beforeId=${encodeURIComponent(last.id)}`}
+      hx-target="#recent-request-rows"
+      hx-swap="beforeend"
+      hx-disabled-elt="this"
+    >
+      Load more requests
+    </button>
   );
 };


### PR DESCRIPTION
## What

Revamps the Activity page's Recent Requests table to make it more useful for debugging request history.

- Keeps the table compact at four columns: Time, Model, Tokens, Result
- Shows API key name and IP behind a compact colored info marker in the Time column
- Links model names to their model detail pages and prefers OpenRouter display names when available
- Splits usage into prompt/completion tokens, e.g. `1,842 in / 731 out`
- Identifies likely failed requests from existing response JSON without a schema migration
- Adds cursor-based "Load more requests" pagination via HTMX

## How

- Extends the recent request query to join API key names and select prompt/completion tokens plus response JSON
- Enriches rows with cached OpenRouter model metadata from the existing model fetcher
- Replaces the generic table rendering with a purpose-built Recent Requests table so mixed content, titles, HTMX partial rows, and the load-more control are straightforward
- Adds `/activity/requests` as an authenticated HTMX endpoint that paginates by `(timestamp, id)` to avoid offset skips/duplicates
- Enables HTMX on the Activity layout and uses existing brand color/style conventions for dark mode

## Why

The old table showed only a raw model slug, total tokens, duration, and IP. That made it hard to understand which key generated a request, whether a row represented a failed provider call, how tokens split between input/output, or to inspect older requests beyond the latest 50.

This keeps the initial change migration-free by deriving error state from the already-stored response JSON. A future migration could add first-class status/error fields if more precise failure reporting is needed.

## Verification

- `bun run typecheck`
- Rendered the real `Activity` view with mock request data and captured desktop/mobile screenshots using Flatpak Chromium headless

<img width="1440" height="1100" alt="activity-table" src="https://github.com/user-attachments/assets/5fe22733-f969-4408-9b7a-33d9d2c0ee77" />
<img width="390" height="900" alt="activity-table-mobile" src="https://github.com/user-attachments/assets/629d736c-c9f4-4a0d-b1d9-2389444bfecf" />



## Disclosure

Generated by GPT-5.5 with human oversight.
