### PR TITLE
feat: add GET /proxy/v1/key endpoint for API key balance info

### DIFF
--- a/src/middleware/limits.ts
+++ b/src/middleware/limits.ts
@@ -19,7 +19,7 @@ const startOfUtcDay = () => {
   );
 };
 
-const computeSpent = async (userId: string) => {
+export const computeSpent = async (userId: string) => {
   const startOfDay = startOfUtcDay();
   const pendingCutoff = new Date(Date.now() - PENDING_CHARGE_TTL_MS);
 

--- a/src/routes/proxy/v1/index.ts
+++ b/src/routes/proxy/v1/index.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../lib/models";
 import { getUserStats } from "../../../lib/stats";
 import { blockAICodingAgents, requireApiKey } from "../../../middleware/auth";
+import { computeSpent } from "../../../middleware/limits";
 import type { AppVariables } from "../../../types";
 import { standardLimiter } from "../shared";
 import exa from "./exa";
@@ -44,6 +45,25 @@ proxy.get("/embeddings/models", etag(), async (c) =>
 proxy.get("/stats", standardLimiter, async (c) =>
   c.json(await getUserStats(c.get("user").id)),
 );
+
+proxy.get("/key", standardLimiter, async (c) => {
+  const user = c.get("user");
+  const apiKey = c.get("apiKey");
+
+  const isUnlimited = apiKey?.isUnlimited ?? false;
+  const limit = parseFloat(user.spendingLimitUsd || "4");
+  const usage = await computeSpent(user.id);
+
+  return c.json({
+    data: {
+      label: apiKey?.name ?? "",
+      is_unlimited: isUnlimited,
+      limit: isUnlimited ? null : limit,
+      usage,
+      limit_remaining: isUnlimited ? null : Math.max(0, limit - usage),
+    },
+  });
+});
 
 proxy.route("/", general);
 proxy.route("/", moderations);


### PR DESCRIPTION
## What

Adds a new `GET /proxy/v1/key` endpoint that returns information about the API key used for authentication, including the daily spending limit, current usage, and remaining balance.

This is similar to [OpenRouter's `GET /api/v1/key`](https://openrouter.ai/docs/api/api-reference/api-keys/get-current-key) endpoint.

## Why

Currently there's no programmatic way to check how much of your daily spending limit you've used or have remaining. This is useful for:
- Monitoring usage from scripts and tools
- Building dashboards or alerts
- Programmatic budget management

## How it works

**Endpoint:** `GET /proxy/v1/key`  
**Auth:** `Authorization: Bearer sk-hc-v1-...` (same as all other proxy endpoints)

### Example response

```json
{
  "data": {
    "label": "My Key",
    "is_unlimited": false,
    "limit": 4,
    "usage": 1.23,
    "limit_remaining": 2.77
  }
}
```

| Field | Type | Description |
|---|---|---|
| `label` | string | The name assigned to the API key |
| `is_unlimited` | boolean | Whether the key has unlimited spending |
| `limit` | number \| null | Daily spending limit in USD (null if unlimited) |
| `usage` | number | Today's spending in USD (logged costs + pending charges) |
| `limit_remaining` | number \| null | Remaining daily balance in USD (null if unlimited) |

### Usage with curl

```bash
curl https://ai.hackclub.com/proxy/v1/key \
  -H "Authorization: Bearer sk-hc-v1-your-key-here"
```

## Implementation details

- **Exports `computeSpent`** from `src/middleware/limits.ts` so the existing daily spending calculation (logged request costs + pending charges) is reused rather than duplicated
- **Mounts the route at `/proxy/v1/key`** in `src/routes/proxy/v1/index.ts`, matching the OpenRouter pattern where key info is available alongside other API endpoints
- Uses the existing `requireApiKey` middleware for Bearer token authentication
- Includes `standardLimiter` for rate limiting (750 requests / 30 min, same as `/stats`)
- For unlimited keys, `limit` and `limit_remaining` are `null` while `usage` still reflects actual spending

## Files changed

- `src/middleware/limits.ts` — export `computeSpent`
- `src/routes/proxy/v1/index.ts` — add `GET /key` handler + import `computeSpent`

## Type checking & linting

- `tsc --noEmit` passes clean
- `biome check` passes clean