### PR TITLE
fix: label negative costs as variable cost

### DIFF
--- a/src/lib/price.ts
+++ b/src/lib/price.ts
@@ -3,6 +3,7 @@ export function formatPrice(price: string | number): string {
   const num = parseFloat(str);
   if (!str || Number.isNaN(num)) return "N/A";
   if (num === 0) return "Free";
+  if (num < 0) return "Variable cost";
 
   const [rawWhole = "0", rawFraction = ""] = str.split(".");
   const whole = rawWhole.replace(/^0+/, "") || "0";

--- a/src/views/model.tsx
+++ b/src/views/model.tsx
@@ -15,6 +15,7 @@ function formatPricing(pricePerToken?: string): string {
   if (!pricePerToken) return "N/A";
   const price = parseFloat(pricePerToken) * 1_000_000;
   if (price === 0) return "Free";
+  if (price < 0) return "Variable cost";
   if (price < 0.01) return `$${price.toFixed(4)}`;
   if (price < 1) return `$${price.toFixed(2)}`;
   return `$${price.toFixed(2)}`;


### PR DESCRIPTION
## what
show `Variable cost` instead of a negative dollar amount in the UI.

## why
negative prices represent variable-cost models, not a literal charge to display as a negative currency value. zero-cost models already display as `Free`.

## fix
update both model pricing and activity cost formatters to return `Variable cost` for negative values.

## checks
- targeted Biome check passed
- typecheck passed
- repository-wide format check remains blocked by pre-existing formatting issues in `drizzle/meta/0016_snapshot.json` and `drizzle/meta/_journal.json`